### PR TITLE
Implement API-backed auth and add seed user

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,10 @@
     "test:coverage": "jest --coverage",
     "migrate": "npx prisma migrate dev",
     "generate": "npx prisma generate",
-    "studio": "npx prisma studio"
+    "studio": "npx prisma studio",
+    "prisma:generate": "prisma generate",
+    "prisma:migrate": "prisma migrate dev --name init",
+    "prisma:seed": "ts-node prisma/seed.ts"
   },
   "dependencies": {
     "@prisma/client": "^5.22.0",

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -1,0 +1,20 @@
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
+
+const prisma = new PrismaClient();
+
+async function main() {
+  const email = "procontactmitsuki@gmail.com";
+  const password = "Charllote2811";
+  const hash = await bcrypt.hash(password, 10);
+
+  await prisma.user.upsert({
+    where: { email },
+    update: { password: hash },
+    create: { email, password: hash, name: "Mitsuki" },
+  });
+
+  console.log("Seeded:", email);
+}
+
+main().finally(() => prisma.$disconnect());

--- a/frontend/.env
+++ b/frontend/.env
@@ -1,0 +1,4 @@
+REACT_APP_API_URL=http://localhost:3001/api
+
+# Docker
+# REACT_APP_API_URL=http://backend:3001/api

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1,34 +1,35 @@
-import axios from 'axios';
+import axios from "axios";
 
-const baseURL = process.env.REACT_APP_API_URL || 'http://localhost:3001/api';
-console.log('🔗 API Base URL:', baseURL);
+const baseURL = process.env.REACT_APP_API_URL || "http://localhost:3001/api";
+console.log("🔗 API Base URL:", baseURL);
 
 export const api = axios.create({
   baseURL,
   timeout: 30000,
 });
 
-// Interceptor to automatically add token
 api.interceptors.request.use(
   (config) => {
-    const token = localStorage.getItem('token');
+    const token = localStorage.getItem("token");
     if (token) {
-      config.headers.Authorization = `Bearer ${token}`;
+      config.headers = config.headers ?? {};
+      (config.headers as Record<string, string>)["Authorization"] = `Bearer ${token}`;
     }
     return config;
   },
-  (error) => {
-    return Promise.reject(error);
-  }
+  (error) => Promise.reject(error)
 );
 
-// Interceptor to handle responses
 api.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      localStorage.removeItem('token');
-      window.location.href = '/login';
+      localStorage.removeItem("token");
+      delete api.defaults.headers.common["Authorization"];
+
+      if (typeof window !== "undefined" && window.location.pathname !== "/login") {
+        window.location.href = "/login";
+      }
     }
     return Promise.reject(error);
   }


### PR DESCRIPTION
## Summary
- integrate the AuthContext with the real authentication API, persisting tokens and verifying stored sessions
- update the Axios client to honor `REACT_APP_API_URL`, refresh auth headers from storage, and redirect to `/login` on 401s
- add the frontend `.env`, Prisma seed script, and npm helpers to bootstrap the Mitsuki test account

## Testing
- `npm run prisma:generate`
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/commitsight npm run prisma:migrate` *(fails: database not reachable in container)*
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/commitsight npm run prisma:seed` *(fails: database not reachable in container)*
- `DATABASE_URL=postgresql://postgres:postgres@localhost:5432/commitsight JWT_SECRET=secret npm run dev`
- `npm start`

